### PR TITLE
Allow user to be assigned to an area on registration

### DIFF
--- a/backEnd/prisma/migrations/20250722201131_area/migration.sql
+++ b/backEnd/prisma/migrations/20250722201131_area/migration.sql
@@ -1,0 +1,13 @@
+-- AlterTable
+ALTER TABLE "user" ADD COLUMN     "areaId" INTEGER;
+
+-- CreateTable
+CREATE TABLE "area" (
+    "id" SERIAL NOT NULL,
+    "name" TEXT NOT NULL,
+
+    CONSTRAINT "area_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "user" ADD CONSTRAINT "user_areaId_fkey" FOREIGN KEY ("areaId") REFERENCES "area"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/backEnd/prisma/migrations/20250722201926_city/migration.sql
+++ b/backEnd/prisma/migrations/20250722201926_city/migration.sql
@@ -1,0 +1,10 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `name` on the `area` table. All the data in the column will be lost.
+  - Added the required column `city` to the `area` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "area" DROP COLUMN "name",
+ADD COLUMN     "city" TEXT NOT NULL;

--- a/backEnd/prisma/migrations/20250722202557_unique_name/migration.sql
+++ b/backEnd/prisma/migrations/20250722202557_unique_name/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[city]` on the table `area` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateIndex
+CREATE UNIQUE INDEX "area_city_key" ON "area"("city");

--- a/backEnd/prisma/schema.prisma
+++ b/backEnd/prisma/schema.prisma
@@ -9,6 +9,12 @@ generator client {
   output   = "../generated/prisma"
 }
 
+model area {
+  id    Int    @id @default(autoincrement())
+  name  String
+  users user[]
+}
+
 model user {
   id                    Int            @id @default(autoincrement())
   username              String         @unique
@@ -25,6 +31,8 @@ model user {
   notifications         notification[]
   donationPosts         donationPost[]
   requestPosts          requestPost[]
+  area                  area?          @relation(fields: [areaId], references: [id])
+  areaId                Int?
 }
 
 model notification {

--- a/backEnd/prisma/schema.prisma
+++ b/backEnd/prisma/schema.prisma
@@ -11,7 +11,7 @@ generator client {
 
 model area {
   id    Int    @id @default(autoincrement())
-  name  String
+  city  String @unique
   users user[]
 }
 

--- a/backEnd/routes/userCRUD.js
+++ b/backEnd/routes/userCRUD.js
@@ -28,6 +28,21 @@ router.post("/signup", async (req, res) => {
     return res.status(400).json({ message: "Email already in use." });
   }
 
+  const partsOfAddress = address.split(/,/);
+  const city = partsOfAddress[1].trim();
+
+  let area = await prisma.area.findUnique({
+    where: { city: city },
+  });
+
+  if (area == null) {
+    area = await prisma.area.create({
+      data: {
+        city
+      }
+    });
+  }
+
   const passwordHash = await bcrypt.hash(password, 10);
 
   const newUser = await prisma.user.create({
@@ -39,9 +54,11 @@ router.post("/signup", async (req, res) => {
       phoneNumber,
       address,
       preferredMeetTime,
-      preferredMeetLocation
+      preferredMeetLocation,
+      areaId: area.id
     }
   });
+
   res.json({ message: "Sign Up Succesful!" });
 })
 

--- a/backEnd/routes/userCRUD.js
+++ b/backEnd/routes/userCRUD.js
@@ -29,7 +29,7 @@ router.post("/signup", async (req, res) => {
   }
 
   const partsOfAddress = address.split(/,/);
-  const city = partsOfAddress[1].trim();
+  const city = partsOfAddress[1].trim().toLowerCase();
 
   let area = await prisma.area.findUnique({
     where: { city: city },
@@ -42,7 +42,6 @@ router.post("/signup", async (req, res) => {
       }
     });
   }
-
   const passwordHash = await bcrypt.hash(password, 10);
 
   const newUser = await prisma.user.create({


### PR DESCRIPTION
## Description
This PR will define a new model called area. Area will hold a list of users in the area. This occurs when someone registers on the page. we will parse what city they are in and assign them to that area. if that area does not exist yet, we will create a new area for them. This will be used later down the road when we create area based notifications.

## Milestones
Allow the user to be assigned to the area they are in.

## Resources
N/A

## Test Plan
Creating a single user
<img width="992" height="479" alt="image" src="https://github.com/user-attachments/assets/ef35cc0b-15ae-4c04-87bd-279cabe6ab70" />
Creating a secondary user:
<img width="909" height="460" alt="image" src="https://github.com/user-attachments/assets/b142ee3e-eee5-404e-9dde-eecff801cd3a" />
Creating a user in a new area, triggering a new area being created:
<img width="934" height="410" alt="image" src="https://github.com/user-attachments/assets/981790de-71f5-4140-810b-b37ca427d831" />
showing that users are tied to the areas:
<img width="1041" height="288" alt="image" src="https://github.com/user-attachments/assets/ae02b8bf-7f2f-47b2-a998-2331e70d2b3b" />
