### PR TITLE
Allows users in the area to get a notification when a new object is posted

### DIFF
--- a/backEnd/classes/WebSocketManger.js
+++ b/backEnd/classes/WebSocketManger.js
@@ -1,4 +1,7 @@
 
+const { PrismaClient } = require("../generated/prisma");
+const prisma = new PrismaClient;
+
 class WebSocketManager {
 
     constructor() {
@@ -19,6 +22,19 @@ class WebSocketManager {
         if (userId in this.onlineUsers) {
             io.to(this.onlineUsers[userId]).emit("getNotification", { type, description })
         }
+    }
+
+    async areaPost(areaId, type, description) {
+        const area = await prisma.area.findUnique({
+            where: { id: areaId },
+            include: {
+                users: true
+            }
+        })
+        // console.log(usersInArea.);
+        // this.getUser(areaId);
+        //will need to grab all users in area
+        //will then perform a similair check as before with the getNotification
     }
 }
 module.exports = WebSocketManager;

--- a/backEnd/classes/WebSocketManger.js
+++ b/backEnd/classes/WebSocketManger.js
@@ -25,7 +25,7 @@ class WebSocketManager {
         }
     }
 
-    async areaPost(areaId, type, description) {
+    async areaPost(userId, areaId, type, description) {
         const area = await prisma.area.findUnique({
             where: { id: areaId },
             include: {
@@ -33,7 +33,7 @@ class WebSocketManager {
             }
         })
         for (let i = 0; i < area.users.length; i++) {
-            if (area.users[i].id in this.onlineUsers) {
+            if (area.users[i].id in this.onlineUsers && area.users[i].id !== userId) {
                 this.io.to(this.onlineUsers[area.users[i].id]).emit("getNotification", { type, description })
             }
         }

--- a/backEnd/classes/WebSocketManger.js
+++ b/backEnd/classes/WebSocketManger.js
@@ -4,8 +4,9 @@ const prisma = new PrismaClient;
 
 class WebSocketManager {
 
-    constructor() {
+    constructor(io) {
         this.onlineUsers = {};
+        this.io = io
     }
 
     addNewUser(userId, socketId) {
@@ -18,9 +19,9 @@ class WebSocketManager {
         }
     }
 
-    requestNotification(userId, io, type, description) {
+    requestNotification(userId, type, description) {
         if (userId in this.onlineUsers) {
-            io.to(this.onlineUsers[userId]).emit("getNotification", { type, description })
+            this.io.to(this.onlineUsers[userId]).emit("getNotification", { type, description })
         }
     }
 
@@ -31,10 +32,11 @@ class WebSocketManager {
                 users: true
             }
         })
-        // console.log(usersInArea.);
-        // this.getUser(areaId);
-        //will need to grab all users in area
-        //will then perform a similair check as before with the getNotification
+        for (let i = 0; i < area.users.length; i++) {
+            if (area.users[i].id in this.onlineUsers) {
+                this.io.to(this.onlineUsers[area.users[i].id]).emit("getNotification", { type, description })
+            }
+        }
     }
 }
 module.exports = WebSocketManager;

--- a/backEnd/index.js
+++ b/backEnd/index.js
@@ -34,8 +34,8 @@ io.on('connection', (socket) => {
   socket.on("requestSubmitted", (data) => {
     manager.requestNotification(data.userId, data.type, data.description);
   })
-  socket.on("postCreated", ({ areaId, type, description }) => {
-    manager.areaPost(areaId, type, description);
+  socket.on("postCreated", ({ userId, areaId, type, description }) => {
+    manager.areaPost(userId, areaId, type, description);
   })
 });
 

--- a/backEnd/index.js
+++ b/backEnd/index.js
@@ -6,8 +6,6 @@ const cors = require('cors')
 const PORT = 3000;
 const app = express()
 const WebSocketManager = require('./classes/WebSocketManger');
-const manager = new WebSocketManager();
-
 const server = http.createServer(app)
 const io = require("socket.io")(server, {
   cors: {
@@ -15,6 +13,7 @@ const io = require("socket.io")(server, {
     methods: ["GET", "POST"]
   }
 });
+const manager = new WebSocketManager(io);
 
 app.use(express.json());
 app.use(
@@ -33,7 +32,7 @@ io.on('connection', (socket) => {
     manager.deleteUser(userId);
   })
   socket.on("requestSubmitted", (data) => {
-    manager.requestNotification(data.userId, io, data.type, data.description);
+    manager.requestNotification(data.userId, data.type, data.description);
   })
   socket.on("postCreated", ({ areaId, type, description }) => {
     manager.areaPost(areaId, type, description);

--- a/backEnd/index.js
+++ b/backEnd/index.js
@@ -35,6 +35,9 @@ io.on('connection', (socket) => {
   socket.on("requestSubmitted", (data) => {
     manager.requestNotification(data.userId, io, data.type, data.description);
   })
+  socket.on("postCreated", ({ areaId, type, description }) => {
+    manager.areaPost(areaId, type, description);
+  })
 });
 
 server.listen(3000)

--- a/backEnd/routes/donationPostCRUD.js
+++ b/backEnd/routes/donationPostCRUD.js
@@ -74,7 +74,7 @@ router.post('/users/:userId/donations', isAuthenticated, async (req, res) => {
   if (req.session.userId !== userId) {
     return res.status(401).json({ message: "Invalid User" });
   }
-  const { title, description, photo, itemState } = req.body;
+  const { title, description, photo, itemState, type, notificationDescription } = req.body;
   const newDonationPost = await prisma.donationPost.create({
     data: {
       title,
@@ -84,6 +84,14 @@ router.post('/users/:userId/donations', isAuthenticated, async (req, res) => {
       userId
     }
   });
+
+  const newNotification = await prisma.notification.create({
+    data: {
+      type,
+      description: notificationDescription,
+      userId: userId
+    }
+  })
   res.json(newDonationPost);
 })
 

--- a/frontEnd/src/PostCreationPage.jsx
+++ b/frontEnd/src/PostCreationPage.jsx
@@ -3,6 +3,7 @@ import "./App.css";
 import Navigation from "./components/nav";
 import { Context } from "./App";
 import usePostCreation from "./utils/usePostCreation";
+import { socket } from "./utils/socket";
 //main page layout for the page
 function PostCreationPage() {
   const { user } = useContext(Context);
@@ -14,6 +15,7 @@ function PostCreationPage() {
     formData.delete("type");
     const readableData = Object.fromEntries(formData);
     fetchPostCreation(user.id, JSON.stringify(readableData), type);
+    socket.emit("postCreated", {areaId: user.areaId, type : "New Donation In Your Area", description: `${user.username} in your area posted a new item titled: ${readableData.title}`})
   };
 
   return (

--- a/frontEnd/src/PostCreationPage.jsx
+++ b/frontEnd/src/PostCreationPage.jsx
@@ -16,8 +16,9 @@ function PostCreationPage() {
     const readableData = Object.fromEntries(formData);
     readableData.type = "New Donation In Your Area";
     readableData.notificationDescription = `${user.username} in your area posted a new item titled: ${readableData.title}`
+    readableData.areaId = user.areaId;
     fetchPostCreation(user.id, JSON.stringify(readableData), type);
-    socket.emit("postCreated", {areaId: user.areaId, type : "New Donation In Your Area", description: `${user.username} in your area posted a new item titled: ${readableData.title}`})
+    socket.emit("postCreated", {userId: user.id, areaId: user.areaId, type : "New Donation In Your Area", description: `${user.username} in your area posted a new item titled: ${readableData.title}`})
   };
 
   return (

--- a/frontEnd/src/PostCreationPage.jsx
+++ b/frontEnd/src/PostCreationPage.jsx
@@ -14,6 +14,8 @@ function PostCreationPage() {
     const type = Object.fromEntries(formData).type;
     formData.delete("type");
     const readableData = Object.fromEntries(formData);
+    readableData.type = "New Donation In Your Area";
+    readableData.notificationDescription = `${user.username} in your area posted a new item titled: ${readableData.title}`
     fetchPostCreation(user.id, JSON.stringify(readableData), type);
     socket.emit("postCreated", {areaId: user.areaId, type : "New Donation In Your Area", description: `${user.username} in your area posted a new item titled: ${readableData.title}`})
   };


### PR DESCRIPTION
## Description
This pull request will send a notification to everyone in the user area. If the user id is the one who just posted the item it will not send him a notification. This is done to not have erroneous updates to the user. This builds on the area object that i had implemented earlier. One of the blocks I ran into while implementing this was getting data to persist over reloads. I had to figure out how I could send the data immediately through the web socket, and then store it in the back end. It was a little bit to juggle but I figured it out.

## Milestones
Allows the user to see updates in their area.
## Resources
N/A

## Test Plan
From this notification we want to 
1. Notify everyone in the area
2. if the person is the one who posted don't notify them
3. get the notification to appear in the backend and immediately when the creation occurs
The video below shows all of these. I initially show the users saved to the area in the backend to evidence which user's should get the notification. I then Create the post and show that a new notification appeared immediately in the front end and persisted in the backend. Then I show that the one who created it did not get a notification for the new post.
<div>
    <a href="https://www.loom.com/share/91e104cff7b34c649848f025eaf2fa84">
      <p>Videos | Library | Loom - 23 July 2025 - Watch Video</p>
    </a>
    <a href="https://www.loom.com/share/91e104cff7b34c649848f025eaf2fa84">
      <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/91e104cff7b34c649848f025eaf2fa84-1b01c1d1bc353b3e-full-play.gif">
    </a>
  </div>
