### PR TITLE
Allow the backend CRUD to call upon the WebSocket manager

### DIFF
--- a/backEnd/classes/WebSocketManger.js
+++ b/backEnd/classes/WebSocketManger.js
@@ -25,13 +25,7 @@ class WebSocketManager {
         }
     }
 
-    async areaPost(userId, areaId, type, description) {
-        const area = await prisma.area.findUnique({
-            where: { id: areaId },
-            include: {
-                users: true
-            }
-        })
+    async areaPost(userId, area, type, description) {
         const oneDay = 24 * 60 * 60 * 1000;
         const now = new Date(Date.now()).getTime();
         for (let i = 0; i < area.users.length; i++) {

--- a/backEnd/index.js
+++ b/backEnd/index.js
@@ -1,5 +1,5 @@
 
-const express = require('express')
+const express = require('express');
 const session = require('express-session');
 const http = require("http");
 const cors = require('cors')
@@ -14,6 +14,7 @@ const io = require("socket.io")(server, {
   }
 });
 const manager = new WebSocketManager(io);
+module.exports = manager;
 
 app.use(express.json());
 app.use(
@@ -30,9 +31,6 @@ io.on('connection', (socket) => {
   })
   socket.on("logout", (userId) => {
     manager.deleteUser(userId);
-  })
-  socket.on("requestSubmitted", (data) => {
-    manager.requestNotification(data.userId, data.type, data.description);
   })
   socket.on("postCreated", ({ userId, areaId, type, description }) => {
     manager.areaPost(userId, areaId, type, description);
@@ -59,6 +57,7 @@ app.use(session({
 }));
 
 
+
 app.use(userRoutes);
 app.use(requestPostRoutes);
 app.use(donationPostRoutes);
@@ -67,3 +66,4 @@ app.use(possibleRecipientRoutes);
 app.listen(PORT, () => {
   console.log(`Server is running on http://localhost:${PORT}`)
 })
+

--- a/backEnd/index.js
+++ b/backEnd/index.js
@@ -29,9 +29,6 @@ io.on('connection', (socket) => {
     const socketId = socket.id;
     manager.addNewUser(userId, socketId);
   })
-  socket.on("logout", (userId) => {
-    manager.deleteUser(userId);
-  })
   socket.on("postCreated", ({ userId, areaId, type, description }) => {
     manager.areaPost(userId, areaId, type, description);
   })

--- a/backEnd/index.js
+++ b/backEnd/index.js
@@ -29,9 +29,6 @@ io.on('connection', (socket) => {
     const socketId = socket.id;
     manager.addNewUser(userId, socketId);
   })
-  socket.on("postCreated", ({ userId, areaId, type, description }) => {
-    manager.areaPost(userId, areaId, type, description);
-  })
 });
 
 server.listen(3000)

--- a/backEnd/routes/donationPostCRUD.js
+++ b/backEnd/routes/donationPostCRUD.js
@@ -2,6 +2,8 @@ const express = require('express');
 const router = express.Router();
 const { PrismaClient } = require('../generated/prisma')
 const prisma = new PrismaClient;
+const manager = require('../index')
+
 
 const isAuthenticated = (req, res, next) => {
   if (!req.session.userId) {
@@ -95,7 +97,7 @@ router.post('/users/:userId/donations', isAuthenticated, async (req, res) => {
       users: true
     }
   })
-
+  manager.areaPost(userId, area, type, notificationDescription)
   for (let i = 0; i < area.users.length; i++) {
     if (area.users[i].id !== userId && now - area.users[i].lastNotificationReceived.getTime() > oneDay) {
       const newNotification = await prisma.notification.create({

--- a/backEnd/routes/possibleRecipientCRUD.js
+++ b/backEnd/routes/possibleRecipientCRUD.js
@@ -3,6 +3,7 @@ const router = express.Router();
 const { PrismaClient } = require('../generated/prisma')
 const prisma = new PrismaClient;
 const RecipientRecommender = require('../classes/RecipientRecommender')
+const manager = require('../index')
 
 router.get('/users/:userId/donations/:postId/possibleRecipients', async (req, res) => {
   const postId = parseInt(req.params.postId);
@@ -78,6 +79,7 @@ router.post('/users/:userId/donations/:postId/possibleRecipients', async (req, r
       userId: userId
     }
   })
+  manager.requestNotification(userId, type, description);
   const updatedNote = await prisma.user.update({
     where: { id: parseInt(possibleRecipientId) },
     data: {

--- a/backEnd/routes/userCRUD.js
+++ b/backEnd/routes/userCRUD.js
@@ -3,7 +3,7 @@ const router = express.Router();
 const { PrismaClient } = require('../generated/prisma')
 const prisma = new PrismaClient;
 const bcrypt = require('bcrypt')
-
+const manager = require('../index')
 
 router.post("/signup", async (req, res) => {
   const { username, password, email, name, phoneNumber, address, preferredMeetTime, preferredMeetLocation } = req.body;
@@ -62,7 +62,8 @@ router.post("/signup", async (req, res) => {
 })
 
 router.post("/logout", (req, res) => {
-
+  const { id } = req.body;
+  manager.deleteUser(id);
   req.session.destroy((err) => {
     if (err) {
       return res.status(500).json({ error: "Failed to log out" });

--- a/frontEnd/src/PostCreationPage.jsx
+++ b/frontEnd/src/PostCreationPage.jsx
@@ -18,7 +18,6 @@ function PostCreationPage() {
     readableData.notificationDescription = `${signedInUser.username} in your area posted a new item titled: ${readableData.title}`
     readableData.areaId = signedInUser.areaId;
     fetchPostCreation(signedInUser.id, JSON.stringify(readableData), type);
-    socket.emit("postCreated", {userId: signedInUser.id, areaId: signedInUser.areaId, type : "New Donation In Your Area", description: `${signedInUser.username} in your area posted a new item titled: ${readableData.title}`})
   };
 
   return (

--- a/frontEnd/src/components/item.jsx
+++ b/frontEnd/src/components/item.jsx
@@ -3,7 +3,6 @@ import { useContext, useEffect, useRef, useState } from "react";
 import useCreatePossibleRecipient from "../utils/useCreatePossibleRecipient";
 import useAllPossibleRecipients from "../utils/useAllPossibleRecipients";
 import { Context } from "../App";
-import { socket } from "../utils/socket";
 
 function Item({ postType, userId, item }) {
   const itemRef = useRef(null);

--- a/frontEnd/src/components/item.jsx
+++ b/frontEnd/src/components/item.jsx
@@ -37,9 +37,6 @@ function Item({ postType, userId, item }) {
         possibleRecipientId: signedInUser.id,
       })
     );
-
-    socket.emit("requestSubmitted", {userId: item.userId, type : "New Request for Donation Item", description: `${signedInUser.username} requests your item titled: ${item.title}`})
-
     setRequestSubmitted(true);
   };
 

--- a/frontEnd/src/components/nav.jsx
+++ b/frontEnd/src/components/nav.jsx
@@ -15,7 +15,6 @@ function Navigation() {
     event.preventDefault();
     fetchLogout(JSON.stringify({id : signedInUserId}));
     sessionStorage.clear();
-    socket.emit("logout", signedInUser.id);
     setSignedInUser(null);
     navigate("/login");
   };

--- a/frontEnd/src/components/nav.jsx
+++ b/frontEnd/src/components/nav.jsx
@@ -8,11 +8,12 @@ import { socket } from "../utils/socket";
 function Navigation() {
   const navigate = useNavigate();
   const { signedInUser, setSignedInUser } = useContext(Context);
+  const signedInUserId = signedInUser.id;
   const { fetchLogout } = useLogout();
 
   const logOut = async (event) => {
     event.preventDefault();
-    fetchLogout();
+    fetchLogout(JSON.stringify({id : signedInUserId}));
     sessionStorage.clear();
     socket.emit("logout", signedInUser.id);
     setSignedInUser(null);

--- a/frontEnd/src/utils/useLogout.js
+++ b/frontEnd/src/utils/useLogout.js
@@ -1,12 +1,12 @@
-import { useContext} from "react";
+import { useContext } from "react";
 import useCCFetch from "./useCCFetch";
 import { Context } from "../App";
 
-export default function useLogout () {
-    const { fetchData} = useCCFetch();
+export default function useLogout() {
+    const { fetchData } = useCCFetch();
     const { backendUrl } = useContext(Context);
-    const fetchLogout = async() => {
-        await fetchData(`${backendUrl}/logout`, "POST");
+    const fetchLogout = async (body) => {
+        await fetchData(`${backendUrl}/logout`, "POST", body);
     }
-    return {fetchLogout}
+    return { fetchLogout }
 }


### PR DESCRIPTION
## Description
This pull request migrates all of the manager calls away from the index.js and into the CRUD calls. This decreases the complexity of the code by decreasing the backend calls being made. Before we had to emit & fetch whenever we were doing something (requesting, donation creation, etc). Now we only need to fetch and within the fetch we will create make the socket manager call.

## Milestones
Use WebSocket's to provide immediate updates

## Resources
https://stackoverflow.com/questions/32657516/how-to-properly-export-an-es6-class-in-node-4

## Test Plan
There were three calls we were migrating: post creation, request for donation, log out. I tested log out by printing out the new map between sockets and users. This printed without the user that logged out so i knew it was good. For Request I opened the donors page and looked at his notifications. When a request was hit i saw it update and reloaded to make sure it persisted. I followed the same logic for post creation but I decreased the time between posts so I wouldn't wait a full day.
