### PR TITLE
Allows the initial posts be fetched using a priority queue

### DIFF
--- a/backEnd/classes/Notification.js
+++ b/backEnd/classes/Notification.js
@@ -1,9 +1,0 @@
-class Notification {
-    constructor(type, description, timeCreated) {
-        this.type = type;
-        this.description = description;
-        this.timeCreated = timeCreated
-    }
-}
-
-module.exports = Notification;

--- a/backEnd/classes/Notification.js
+++ b/backEnd/classes/Notification.js
@@ -1,0 +1,9 @@
+class Notification {
+    constructor(type, description, timeCreated) {
+        this.type = type;
+        this.description = description;
+        this.timeCreated = timeCreated
+    }
+}
+
+module.exports = Notification;

--- a/backEnd/classes/PriorityQueue.js
+++ b/backEnd/classes/PriorityQueue.js
@@ -1,0 +1,13 @@
+import Notification from "./Notification"
+class PriorityQueue {
+    constructor() {
+        this.items = []
+    }
+
+    getQueue() {
+        return this.items;
+    }
+
+}
+
+export default PriorityQueue;

--- a/backEnd/classes/PriorityQueue.js
+++ b/backEnd/classes/PriorityQueue.js
@@ -1,13 +1,52 @@
-import Notification from "./Notification"
+
 class PriorityQueue {
     constructor() {
-        this.items = []
+        this.notifications = []
     }
 
-    getQueue() {
-        return this.items;
+    typeSanitization(type) {
+        if (type.startsWith("Multiple")) {
+            return 1;
+        } else if (type.startsWith("New Donation")) {
+            return 2;
+        } else if (type.startsWith("New Request")) {
+            return 3;
+        }
+    }
+
+    getPriority(notificaiton) {
+        const now = new Date(Date.now()).getTime();
+        const timeNormalized = 1 - (now - notificaiton.timeCreated.getTime()) / (7 * 24 * 60 * 60 * 1000)
+        const timeScaled = Math.pow(timeNormalized, 2);
+        const timeWeighted = timeScaled * 50;
+        const priority = timeWeighted + notificaiton.typeNum * 10;
+        return priority;
+    }
+
+    enqueue(notification) {
+
+        let inserted = false;
+        notification.typeNum = this.typeSanitization(notification.type);
+        notification.priority = this.getPriority(notification);
+
+        for (let i = 0; i < this.notifications.length; i++) {
+            if (notification.priority >= this.notifications[i].priority) {
+                this.notifications.splice(i, 0, notification);
+                inserted = true;
+                break;
+            }
+        }
+        if (!inserted) {
+            this.notifications.push(notification);
+        }
+    }
+
+    deQueue() {
+        if (this.notifications.isEmpty()) {
+            return null
+        }
+        return this.notifications.unshift();
     }
 
 }
-
-export default PriorityQueue;
+module.exports = PriorityQueue;

--- a/backEnd/classes/PriorityQueue.js
+++ b/backEnd/classes/PriorityQueue.js
@@ -42,10 +42,14 @@ class PriorityQueue {
     }
 
     deQueue() {
-        if (this.notifications.isEmpty()) {
+        if (this.isEmpty()) {
             return null
         }
-        return this.notifications.unshift();
+        return this.notifications.shift();
+    }
+
+    isEmpty() {
+        return this.notifications.length === 0;
     }
 
 }

--- a/backEnd/classes/WebSocketManger.js
+++ b/backEnd/classes/WebSocketManger.js
@@ -3,9 +3,9 @@ const prisma = new PrismaClient;
 const PriorityQueue = require("./PriorityQueue")
 
 class WebSocketManager {
-    static DAYS_IN_MS = 24 * 60 * 60 * 1000;
-    static REMINDER_THRESHOLD_TIME_MS = 3 * 24 * 60 * 60 * 1000;
     constructor(io) {
+        this.DAYS_IN_MS = 24 * 60 * 60 * 1000;
+        this.REMINDER_THRESHOLD_TIME_MS = 3 * 24 * 60 * 60 * 1000;
         this.onlineUsers = {};
         this.io = io
         const timer = 24 * 60 * 60 * 1000;
@@ -22,7 +22,7 @@ class WebSocketManager {
         })
         const filteredDonations = allDonations.filter(donation =>
             donation.possibleRecipients.length > 2 &&
-            now - donation.timeCreated.getTime() > REMINDER_THRESHOLD_TIME_MS);
+            now - donation.timeCreated.getTime() > this.REMINDER_THRESHOLD_TIME_MS);
         for (let i = 0; i < filteredDonations.length; i++) {
             if (filteredDonations[i].userId in this.onlineUsers) {
                 this.io.to(this.onlineUsers[filteredDonations[i].userId].socketId).emit("getNotification", {
@@ -48,7 +48,7 @@ class WebSocketManager {
             where: { userId: parseInt(userId) },
         });
         const lastWeeksNotifications = individualUserNotifications.filter(
-            notification => (now - notification.timeCreated.getTime()) < 7 * DAYS_IN_MS
+            notification => (now - notification.timeCreated.getTime()) < 7 * this.DAYS_IN_MS
         )
 
         lastWeeksNotifications.sort((a, b) => {
@@ -82,7 +82,7 @@ class WebSocketManager {
     async areaPost(userId, area, type, description) {
         const now = new Date(Date.now()).getTime();
         for (let i = 0; i < area.users.length; i++) {
-            if (area.users[i].id in this.onlineUsers && area.users[i].id !== userId && (now - area.users[i].lastNotificationReceived.getTime() > DAYS_IN_MS)) {
+            if (area.users[i].id in this.onlineUsers && area.users[i].id !== userId && (now - area.users[i].lastNotificationReceived.getTime() > this.DAYS_IN_MS)) {
                 this.io.to(this.onlineUsers[area.users[i].id].socketId).emit("getNotification", { type, description })
             }
         }

--- a/backEnd/classes/WebSocketManger.js
+++ b/backEnd/classes/WebSocketManger.js
@@ -87,5 +87,16 @@ class WebSocketManager {
             }
         }
     }
+
+    getInitialPosts(userId) {
+        if (userId in this.onlineUsers) {
+            const userQueue = this.onlineUsers[userId].userQueue;
+            const initNotifs = []
+            while (!userQueue.isEmpty()) {
+                initNotifs.push(userQueue.deQueue())
+            }
+            return initNotifs;
+        }
+    }
 }
 module.exports = WebSocketManager;

--- a/backEnd/prisma/migrations/20250724134150_time_created_notification/migration.sql
+++ b/backEnd/prisma/migrations/20250724134150_time_created_notification/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "notification" ADD COLUMN     "timeCreated" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;

--- a/backEnd/prisma/schema.prisma
+++ b/backEnd/prisma/schema.prisma
@@ -37,10 +37,11 @@ model user {
 }
 
 model notification {
-  id          Int    @id @default(autoincrement())
+  id          Int      @id @default(autoincrement())
   type        String
   description String
-  user        user?  @relation(fields: [userId], references: [id])
+  timeCreated DateTime @default(now())
+  user        user?    @relation(fields: [userId], references: [id])
   userId      Int?
 }
 

--- a/backEnd/routes/userCRUD.js
+++ b/backEnd/routes/userCRUD.js
@@ -145,20 +145,10 @@ router.get('/users/:userId/notifications', async (req, res) => {
   if (req.session.userId !== userId) {
     return res.status(401).json({ message: "Not Authorized" });
   }
-  const individualUser = await prisma.user.findUnique({
-    where: { id: parseInt(userId) },
-    include: {
-      notifications: true,
-    }
-  });
-  individualUser.notifications.sort((a, b) => {
-    if (a.id < b.id) {
-      return 1;
-    } else if (a.id > b.id) {
-      return -1;
-    }
-  })
-  res.json(individualUser.notifications);
+
+  const notifications = manager.getInitialPosts(userId);
+
+  res.json(notifications);
 })
 
 //deletes user

--- a/frontEnd/src/App.jsx
+++ b/frontEnd/src/App.jsx
@@ -52,11 +52,11 @@ function App() {
     }
   };
 
-  window.addEventListener('load', () => {
+  useEffect(() => {
     if(signedInUser!==null){
       socket.emit("newUser", signedInUser.id)
     }
-  })
+  }, [])
   return (
     //router functionality for when we navigate to pages
     <Context.Provider value={{ signedInUser, setSignedInUser, backendUrl }}>

--- a/frontEnd/src/NotificationsPage.jsx
+++ b/frontEnd/src/NotificationsPage.jsx
@@ -6,20 +6,13 @@ import useUserNotifications from "./utils/useUserNotifications";
 import { useContext } from "react";
 import { Context } from "./App";
 import { socket } from "./utils/socket";
-import React from "react";
 //main page layout for the page
 function NotificationsPage() {
     const {signedInUser} = useContext(Context);
     const { fetchUserNotifications, notifications, loading} = useUserNotifications(signedInUser.id);
-    useEffect(() => {
-        fetchUserNotifications();
-        
-        return  () => {
-            socket.off("getNotification")
-        }
-    }, [])
 
     useEffect(()=> {
+        fetchUserNotifications();
         socket.on("getNotification", (data) => {
             const newNotif = document.createElement('div')
             newNotif.style.border = "2px solid white"
@@ -33,6 +26,9 @@ function NotificationsPage() {
             newNotif.appendChild(description);
             document.getElementById("main").prepend(newNotif);
         })
+        return  () => {
+            socket.off("getNotification")
+        }
     }, [socket]);
     return (
         <div>

--- a/frontEnd/src/NotificationsPage.jsx
+++ b/frontEnd/src/NotificationsPage.jsx
@@ -13,6 +13,7 @@ function NotificationsPage() {
 
     useEffect(()=> {
         fetchUserNotifications();
+        socket.emit("newUser", signedInUser.id)
         socket.on("getNotification", (data) => {
             const newNotif = document.createElement('div')
             newNotif.style.border = "2px solid white"


### PR DESCRIPTION
## Description
This pull request migrates the logic of loading in the initial posts to the priority queue for the user. We implemented the priority queue so that in the future, we can release notifications on a scheduled basis. The priority queue will organize in which order the notifications will be shown. On startup we will grab the first 10 most recent posts. We will then put them into the priority queue and order them appropriately. Then, when we go to the notifications page, we will dequeue all of them and present them to the user. This way the most recent post will be shown in the order of most priority. This implementation related to the previous recommendation algorithm since I needed to assign a value to all of the notifications. I also had to understand how a priority queue worked and how I could integrate it into the code

## Milestones
Allow a set amount of notifications to be presented

## Resources
https://www.geeksforgeeks.org/javascript/implementation-priority-queue-javascript/

## Test Plan
One of the original problems I was having was that notifications would not appear when I reloaded or moved away form the page. I had to integrate new triggers so that the code would run on reload and navigations. I tested ordering by printing out all notifications in the queue. I checked this based on the time they were created and what type of posts they are. 
<img width="862" height="724" alt="image" src="https://github.com/user-attachments/assets/8b47555f-1214-45d5-b698-1e55726b2149" />

https://www.loom.com/share/e49cdce3c7fb4319b23ff062a72041b0
