### PR TITLE
Allow the user to see information on how the distance is calculated

### DIFF
--- a/frontEnd/src/components/item.jsx
+++ b/frontEnd/src/components/item.jsx
@@ -63,9 +63,12 @@ function Item({ postType, userId, item }) {
           <p>{item.description}</p>
           <p>Use State: {item.itemState}</p>
           {postType == "donations" && (
-            <p className="distance">Distance: {item.distance}</p>
+            <div>
+              Distance: <span className="distance">{item.distance}</span>
+              <span className="customToolTipDistance">Distance is based on your home address and donors meet up address.</span>
+            </div>
           )}
-
+          <br></br>
           {postType === "donations" && (
             <form className="requestItemForm">
               <label style={{ marginLeft: "10px" }} htmlFor="wantScore">

--- a/frontEnd/src/index.css
+++ b/frontEnd/src/index.css
@@ -60,6 +60,41 @@ select {
   border-color: black transparent transparent transparent;
 }
 
+.customToolTipDistance {
+  display: none;
+  width: 120px;
+  background-color: black;
+  color: #fff;
+  text-align: center;
+  border-radius: 6px;
+  padding: 5px 0;
+  position: absolute;
+  z-index: 1;
+  margin-left: -80px;
+  margin-top: -155px;
+}
+
+.customToolTipDistance::after {
+  content: "";
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  margin-left: -5px;
+  border-width: 5px;
+  border-style: solid;
+  border-color: black transparent transparent transparent;
+}
+
+.distance {
+  text-decoration: underline;
+  text-decoration-style: dotted;
+}
+
+.distance:hover+.customToolTipDistance {
+  display: inline-block;
+}
+
+
 a:hover {
   text-decoration: underline;
 }


### PR DESCRIPTION
## Description
This pull request will create a custom tooltip that will inform the user of how the distance is calculated. when the user first signs up he sets his meet up location and his home address. The distance is calculated using the donor meet up location and the recipient house location.

## Milestones
Custom tooltip

## Resources
N/A

## Test Plan
I hovered over the distance and saw that the tool tip was present. I then resized to make sure resizing would not cause error.
<img width="931" height="378" alt="image" src="https://github.com/user-attachments/assets/c96da711-4a0b-4c29-85b7-ff43e2e1e1e3" />

