### PR TITLE
Allows cleaner fetching for donations.

### DIFF
--- a/backEnd/routes/donationPostCRUD.js
+++ b/backEnd/routes/donationPostCRUD.js
@@ -43,7 +43,11 @@ router.get('/users/:userId/donations/:postId', async (req, res) => {
 
 //gets all donations and calculates the distance between the user and the post
 router.get('/allDonations/:userId', async (req, res) => {
-  const donations = await prisma.donationPost.findMany({})
+  const donations = await prisma.donationPost.findMany({
+    orderBy: {
+      id: "desc"
+    }
+  })
   const userId = parseInt(req.params.userId);
   const signedInUser = await prisma.user.findUnique({
     where: { id: parseInt(userId) }
@@ -58,12 +62,13 @@ router.get('/allDonations/:userId', async (req, res) => {
     const url = `https://maps.googleapis.com/maps/api/distancematrix/json?origins=${origin}&destinations=${donor.preferredMeetLocation}&units=imperial&key=${api_key}`;
     const response = await fetch(url);
     const data = await response.json();
-    if (data.rows[0].elements[0].distance?.text == undefined) {
+    if (data.error_message) {
       donations[i].distance = "ERROR";
     } else {
       donations[i].distance = data.rows[0].elements[0].distance?.text;
     }
   }
+
 
 
   res.json(donations)

--- a/backEnd/routes/donationPostCRUD.js
+++ b/backEnd/routes/donationPostCRUD.js
@@ -87,8 +87,6 @@ router.post('/users/:userId/donations', isAuthenticated, async (req, res) => {
     return res.status(401).json({ message: "Invalid User" });
   }
   const { title, description, photo, itemState, type, notificationDescription, areaId } = req.body;
-  const oneDay = 24 * 60 * 60 * 1000;
-  const now = new Date(Date.now()).getTime();
   const newDonationPost = await prisma.donationPost.create({
     data: {
       title,
@@ -109,7 +107,7 @@ router.post('/users/:userId/donations', isAuthenticated, async (req, res) => {
   })
   manager.areaPost(userId, area, type, notificationDescription)
   for (let i = 0; i < area.users.length; i++) {
-    if (area.users[i].id !== userId && now - area.users[i].lastNotificationReceived.getTime() > oneDay) {
+    if (area.users[i].id !== userId) {
       const newNotification = await prisma.notification.create({
         data: {
           type,

--- a/backEnd/routes/donationPostCRUD.js
+++ b/backEnd/routes/donationPostCRUD.js
@@ -57,10 +57,10 @@ router.get('/allDonations/:userId', async (req, res) => {
   const origin = signedInUser.address;
   const api_key = process.env.GOOGLE_API;
   const userDistances = {};
-
   for (let i = 0; i < donations.length; i++) {
     if (donations[i].userId in userDistances) {
       donations[i].distance = userDistances[donations[i].userId];
+      console.log(donations[i].distance);
     } else {
       const donor = await prisma.user.findUnique({
         where: { id: parseInt(donations[i].userId) }
@@ -73,6 +73,7 @@ router.get('/allDonations/:userId', async (req, res) => {
       } else {
         donations[i].distance = data.rows[0].elements[0].distance?.text;
       }
+      userDistances[donations[i].userId] = donations[i].distance;
     }
   }
 


### PR DESCRIPTION
## Description
This Pr will clean up the the fetching ability for all donations. It will order the donations to be in order or when they were created. It also stores the distance from the API call so that we will not have to query for every single piece of data. This increases efficiency and lets the page load faster
## Milestones
Allows easier fetching for donations
## Resources
N/A
## Test Plan
I put a print in the if check to see if the id is in the map. After the first api call, it printed every single time.
<img width="905" height="668" alt="image" src="https://github.com/user-attachments/assets/63038261-37f8-4a80-8cc9-83c0c56fd063" />

